### PR TITLE
create images dir if not present

### DIFF
--- a/src/backend/plain_player.py
+++ b/src/backend/plain_player.py
@@ -44,7 +44,7 @@ def get_player_positions(inputvideo, plot=False):
     # check if images directory exists, if not create it
     if os.path.exists("images"):
         shutil.rmtree("images")
-        os.makedirs("images")
+    os.makedirs("images")
 
     ffmpeg_cmd_retry = [
         "ffmpeg",


### PR DESCRIPTION
@linkwb please pull down a copy of this pr and confirm on your machine it fixes the issue. 

What I did to confirm on my end:
(i) delete `images/` folder locally and ran workflow w/client + server to confirm I get a similar error
(ii) made the code change indicated in this pr, then reran client + server to confirm the 30 second video clip works as expected on my laptop

